### PR TITLE
Don't convert implicitly non-str arguments to istr

### DIFF
--- a/istr/__init__.py
+++ b/istr/__init__.py
@@ -45,77 +45,74 @@ class istr(str):  # pylint: disable=invalid-name
         return 'istr({})'.format(super().__repr__())
 
     def __eq__(self, other):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return self.normalized == other.normalized
+        try:
+            return self.normalized == self._normalize(other)
+        except TypeError:
+            return NotImplemented
 
     def __lt__(self, other):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return self.normalized < other.normalized
+        try:
+            return self.normalized < self._normalize(other)
+        except TypeError:
+            return NotImplemented
 
     def __le__(self, other):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return self.normalized <= other.normalized
+        try:
+            return self.normalized <= self._normalize(other)
+        except TypeError:
+            return NotImplemented
 
     def __gt__(self, other):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return self.normalized > other.normalized
+        try:
+            return self.normalized > self._normalize(other)
+        except TypeError:
+            return NotImplemented
 
     def __ne__(self, other):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return self.normalized != other.normalized
+        try:
+            return self.normalized != self._normalize(other)
+        except TypeError:
+            return NotImplemented
 
     def __ge__(self, other):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return self.normalized >= other.normalized
+        try:
+            return self.normalized >= self._normalize(other)
+        except TypeError:
+            return NotImplemented
 
     def __hash__(self):
         return hash(self.normalized)
 
     def __contains__(self, other):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return other.normalized in self.normalized
+        return self._normalize(other) in self.normalized
 
     def count(self, other, *args):  # pylint: disable=arguments-differ
-        if not isinstance(other, istr):
-            other = istr(other)
-        return str.count(self.normalized, other.normalized, *args)
+        return str.count(self.normalized, self._normalize(other), *args)
 
     def endswith(self, other, *args):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return str.endswith(self.normalized, other.normalized, *args)
+        return str.endswith(self.normalized, self._normalize(other), *args)
 
     def find(self, other, *args):  # pylint: disable=arguments-differ
-        if not isinstance(other, istr):
-            other = istr(other)
-        return str.find(self.normalized, other.normalized, *args)
+        return str.find(self.normalized, self._normalize(other), *args)
 
     def index(self, other, *args):  # pylint: disable=arguments-differ
-        if not isinstance(other, istr):
-            other = istr(other)
-        return str.index(self.normalized, other.normalized, *args)
+        return str.index(self.normalized, self._normalize(other), *args)
 
     def rfind(self, other, *args):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return str.rfind(self.normalized, other.normalized, *args)
+        return str.rfind(self.normalized, self._normalize(other), *args)
 
     def rindex(self, other, *args):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return str.rindex(self.normalized, other.normalized, *args)
+        return str.rindex(self.normalized, self._normalize(other), *args)
 
     def startswith(self, other, *args):
-        if not isinstance(other, istr):
-            other = istr(other)
-        return str.startswith(self.normalized, other.normalized, *args)
+        return str.startswith(self.normalized, self._normalize(other), *args)
 
     def casefold(self):
         return self.normalized.casefold()
+
+    def _normalize(self, obj):
+        if isinstance(obj, istr):
+            return obj.normalized
+        if isinstance(obj, str):
+            return self.__class__(obj).normalized
+        raise TypeError(f"Argument must be str, not {type(obj)}")

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -106,12 +106,17 @@ def two_samples(faker):
     return original1, munged1, original2, munged2
 
 
+@pytest.fixture
+def non_strings():
+    return None, True, 2, 3.1, [], (), {}, set()
+
+
 def test_repr(sample):
     text, _ = sample
     assert repr(istr(text)) == "istr({})".format(repr(text))
 
 
-def test_eq_equal(sample):
+def test_eq_equal(sample, non_strings):
     original, munged = sample
     if LOG_STRINGS:
         try:
@@ -121,9 +126,11 @@ def test_eq_equal(sample):
             pass
     assert istr(original) == munged
     assert istr(original) == istr(munged)
+    for non_string in non_strings:
+        assert not istr(original) == non_string
 
 
-def test_eq_different(two_samples):
+def test_eq_different(two_samples, non_strings):
     original1, _, _, munged2 = two_samples
     if LOG_STRINGS:
         try:
@@ -133,9 +140,11 @@ def test_eq_different(two_samples):
             pass
     assert not istr(original1) == munged2
     assert not istr(original1) == istr(munged2)
+    for non_string in non_strings:
+        assert not istr(original1) == non_string
 
 
-def test_ne_equal(sample):
+def test_ne_equal(sample, non_strings):
     original, munged = sample
     if LOG_STRINGS:
         try:
@@ -145,9 +154,11 @@ def test_ne_equal(sample):
             pass
     assert not istr(original) != munged
     assert not istr(original) != istr(munged)
+    for non_string in non_strings:
+        assert istr(original) != non_string
 
 
-def test_ne_different(two_samples):
+def test_ne_different(two_samples, non_strings):
     original1, _, _, munged2 = two_samples
     if LOG_STRINGS:
         try:
@@ -157,9 +168,11 @@ def test_ne_different(two_samples):
             pass
     assert istr(original1) != munged2
     assert istr(original1) != istr(munged2)
+    for non_string in non_strings:
+        assert istr(original1) != non_string
 
 
-def test_lt(two_samples):
+def test_lt(two_samples, non_strings):
     original1, munged1, original2, munged2 = two_samples
     is_1_less = original1.casefold() < original2.casefold()
     if is_1_less:
@@ -171,6 +184,9 @@ def test_lt(two_samples):
                 pass
         assert istr(original1) < munged2
         assert istr(original1) < istr(munged2)
+        for non_string in non_strings:
+            with pytest.raises(TypeError):
+                istr(original1) < non_string
     else:
         if LOG_STRINGS:
             try:
@@ -180,9 +196,12 @@ def test_lt(two_samples):
                 pass
         assert istr(original2) < munged1
         assert istr(original2) < istr(munged1)
+        for non_string in non_strings:
+            with pytest.raises(TypeError):
+                istr(original2) < non_string
 
 
-def test_le_different(two_samples):
+def test_le_different(two_samples, non_strings):
     original1, munged1, original2, munged2 = two_samples
     is_1_less = original1.casefold() < original2.casefold()
     if is_1_less:
@@ -194,6 +213,9 @@ def test_le_different(two_samples):
                 pass
         assert istr(original1) <= munged2
         assert istr(original1) <= istr(munged2)
+        for non_string in non_strings:
+            with pytest.raises(TypeError):
+                istr(original1) <= non_string
     else:
         if LOG_STRINGS:
             try:
@@ -203,9 +225,12 @@ def test_le_different(two_samples):
                 pass
         assert istr(original2) <= munged1
         assert istr(original2) <= istr(munged1)
+        for non_string in non_strings:
+            with pytest.raises(TypeError):
+                istr(original2) <= non_string
 
 
-def test_le_equal(sample):
+def test_le_equal(sample, non_strings):
     original, munged = sample
     if LOG_STRINGS:
         try:
@@ -215,9 +240,12 @@ def test_le_equal(sample):
             pass
     assert istr(original) <= munged
     assert istr(original) <= istr(munged)
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original) <= non_string
 
 
-def test_gt(two_samples):
+def test_gt(two_samples, non_strings):
     original1, munged1, original2, munged2 = two_samples
     is_1_greater = original1.casefold() > original2.casefold()
     if is_1_greater:
@@ -229,6 +257,9 @@ def test_gt(two_samples):
                 pass
         assert istr(original1) > munged2
         assert istr(original1) > istr(munged2)
+        for non_string in non_strings:
+            with pytest.raises(TypeError):
+                istr(original1) > non_string
     else:
         if LOG_STRINGS:
             try:
@@ -238,9 +269,12 @@ def test_gt(two_samples):
                 pass
         assert istr(original2) > munged1
         assert istr(original2) > istr(munged1)
+        for non_string in non_strings:
+            with pytest.raises(TypeError):
+                istr(original2) > non_string
 
 
-def test_ge_different(two_samples):
+def test_ge_different(two_samples, non_strings):
     original1, munged1, original2, munged2 = two_samples
     is_1_greater = original1.casefold() > original2.casefold()
     if is_1_greater:
@@ -252,6 +286,9 @@ def test_ge_different(two_samples):
                 pass
         assert istr(original1) >= munged2
         assert istr(original1) >= istr(munged2)
+        for non_string in non_strings:
+            with pytest.raises(TypeError):
+                istr(original1) >= non_string
     else:
         if LOG_STRINGS:
             try:
@@ -261,9 +298,12 @@ def test_ge_different(two_samples):
                 pass
         assert istr(original2) >= munged1
         assert istr(original2) >= istr(munged1)
+        for non_string in non_strings:
+            with pytest.raises(TypeError):
+                istr(original2) >= non_string
 
 
-def test_ge_equal(sample):
+def test_ge_equal(sample, non_strings):
     original, munged = sample
     if LOG_STRINGS:
         try:
@@ -273,6 +313,9 @@ def test_ge_equal(sample):
             pass
     assert istr(original) >= munged
     assert istr(original) >= istr(munged)
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original) >= non_string
 
 
 def test_hash(sample):
@@ -287,7 +330,7 @@ def test_hash(sample):
     assert hash(istr(original)) == hash(istr(munged))
 
 
-def test_contains(sample):
+def test_contains(sample, non_strings):
     original, munged = sample
     munged_part = munged[1:-1]
     if LOG_STRINGS:
@@ -299,9 +342,12 @@ def test_contains(sample):
     assert munged_part not in original
     assert munged_part in istr(original)
     assert istr(munged_part) in istr(original)
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            non_string in istr(original)
 
 
-def test_count(sample):
+def test_count(sample, non_strings):
     original, munged = sample
     munged_other = munged[1:-1]
     if LOG_STRINGS:
@@ -313,9 +359,12 @@ def test_count(sample):
     assert original.count(munged_other) == 0
     assert istr(original).count(munged_other) == 1
     assert istr(original).count(istr(munged_other)) == 1
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original).count(non_string)
 
 
-def test_find(sample):
+def test_find(sample, non_strings):
     original, munged = sample
     pos = 2
     munged_other = munged[pos:-1]
@@ -328,9 +377,12 @@ def test_find(sample):
     assert original.find(munged_other) == -1
     assert istr(original).find(munged_other) == pos
     assert istr(original).find(istr(munged_other)) == pos
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original).find(non_string)
 
 
-def test_index(sample):
+def test_index(sample, non_strings):
     original, munged = sample
     pos = 2
     munged_other = munged[pos:-1]
@@ -344,9 +396,12 @@ def test_index(sample):
         assert original.index(munged_other)
     assert istr(original).index(munged_other) == pos
     assert istr(original).index(istr(munged_other)) == pos
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original).index(non_string)
 
 
-def test_rfind(sample):
+def test_rfind(sample, non_strings):
     original, munged = sample
     pos = 2
     munged_other = munged[pos:-1]
@@ -359,9 +414,12 @@ def test_rfind(sample):
     assert original.rfind(munged_other) == -1
     assert istr(original).rfind(munged_other) == pos
     assert istr(original).rfind(istr(munged_other)) == pos
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original).rfind(non_string)
 
 
-def test_rindex(sample):
+def test_rindex(sample, non_strings):
     original, munged = sample
     pos = 2
     munged_other = munged[pos:-1]
@@ -375,9 +433,12 @@ def test_rindex(sample):
         assert original.rindex(munged_other)
     assert istr(original).rindex(munged_other) == pos
     assert istr(original).rindex(istr(munged_other)) == pos
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original).rindex(non_string)
 
 
-def test_startswith(sample):
+def test_startswith(sample, non_strings):
     original, munged = sample
     munged_other = munged[:-1]
     if LOG_STRINGS:
@@ -389,9 +450,12 @@ def test_startswith(sample):
     assert not original.startswith(munged_other)
     assert istr(original).startswith(munged_other)
     assert istr(original).startswith(istr(munged_other))
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original).startswith(non_string)
 
 
-def test_endswith(sample):
+def test_endswith(sample, non_strings):
     original, munged = sample
     munged_other = munged[1:]
     if LOG_STRINGS:
@@ -403,6 +467,9 @@ def test_endswith(sample):
     assert not original.endswith(munged_other)
     assert istr(original).endswith(munged_other)
     assert istr(original).endswith(istr(munged_other))
+    for non_string in non_strings:
+        with pytest.raises(TypeError):
+            istr(original).endswith(non_string)
 
 
 def test_casefold(sample):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -116,7 +116,7 @@ def test_repr(sample):
     assert repr(istr(text)) == "istr({})".format(repr(text))
 
 
-def test_eq_equal(sample, non_strings):
+def test_eq_equal(sample):
     original, munged = sample
     if LOG_STRINGS:
         try:
@@ -126,8 +126,6 @@ def test_eq_equal(sample, non_strings):
             pass
     assert istr(original) == munged
     assert istr(original) == istr(munged)
-    for non_string in non_strings:
-        assert not istr(original) == non_string
 
 
 def test_eq_different(two_samples, non_strings):
@@ -144,7 +142,7 @@ def test_eq_different(two_samples, non_strings):
         assert not istr(original1) == non_string
 
 
-def test_ne_equal(sample, non_strings):
+def test_ne_equal(sample):
     original, munged = sample
     if LOG_STRINGS:
         try:
@@ -154,8 +152,6 @@ def test_ne_equal(sample, non_strings):
             pass
     assert not istr(original) != munged
     assert not istr(original) != istr(munged)
-    for non_string in non_strings:
-        assert istr(original) != non_string
 
 
 def test_ne_different(two_samples, non_strings):


### PR DESCRIPTION
Fix `istr` methods to not convert implicitly non-str arguments to istr.

Before this PR:
```py
In [1]: from istr import istr

In [2]: istr("hey") > 5
Out[2]: True
```

After this PR:
```py

In [1]: from istr import istr

In [2]: str("hey") > 5
TypeError: '>' not supported between instances of 'str' and 'int'
```